### PR TITLE
fix: Use completing-read

### DIFF
--- a/go-board.el
+++ b/go-board.el
@@ -87,15 +87,15 @@
 
 (defun apply-move (board move)
   (cl-flet ((bset (val data)
-               (let ((data (if (listp (car data)) data (list data))))
-                 (setf (aref board (pos-to-index (aget data :pos)
-                                                 (board-size board)))
-                       (case val
-                         (:B  :B)
-                         (:W  :W)
-                         (:LB (aget data :label))
-                         (:LW (aget data :label))
-                         (t nil))))))
+              (let ((data (if (listp (car data)) data (list data))))
+                (setf (aref board (pos-to-index (aget data :pos)
+                                                (board-size board)))
+                      (case val
+                        (:B  :B)
+                        (:W  :W)
+                        (:LB (aget data :label))
+                        (:LW (aget data :label))
+                        (t nil))))))
     (case (move-type move)
       (:move
        (bset (car move) (cdr move))
@@ -160,8 +160,8 @@
 ;;; Visualization
 (defun board-header (board)
   (cl-flet ((hd (str hd)
-             (put-text-property 0 1 :type `(,hd . :offboard) str)
-             str))
+              (put-text-property 0 1 :type `(,hd . :offboard) str)
+              str))
     (let ((size (board-size board)))
       (concat "   "
               (hd " " :filler)
@@ -174,18 +174,18 @@
 (defun board-pos-to-string (board pos)
   (let ((size (board-size board)))
     (cl-flet ((emph (n)
-                 (cond
-                  ((= size 19)
-                   (or (= 3 n)
-                       (= 4 (- size n))
-                       (= n (/ (- size 1) 2))))
-                  ((= size 13)
-                   (or (= 3 n)
-                       (= 9 n)))
-                  ((= size 9)
-                   (or (= 2 n)
-                       (= 6 n)))))
-           (put (str prop val) (put-text-property 0 (length str) prop val str)))
+                (cond
+                 ((= size 19)
+                  (or (= 3 n)
+                      (= 4 (- size n))
+                      (= n (/ (- size 1) 2))))
+                 ((= size 13)
+                  (or (= 3 n)
+                      (= 9 n)))
+                 ((= size 9)
+                  (or (= 2 n)
+                      (= 6 n)))))
+              (put (str prop val) (put-text-property 0 (length str) prop val str)))
       (let* ((val (aref board (pos-to-index pos size)))
              (str (cond
                    ((equal val :W) white-piece)
@@ -238,19 +238,19 @@
 (defun go-board-paint (&optional start end)
   (interactive "r")
   (cl-flet ((ov (point face &optional back)
-             (let ((ovly (make-overlay point (1+ point))))
-               (overlay-put ovly 'go-pt point)
-               (overlay-put ovly 'face (sym-cat 'go-board face))
-               (when go-board-use-images
-                 (overlay-put ovly 'display
-                              (if (equal face 'filler)
-                                  '(space :width (18))
-                                (eval (sym-cat 'go-board 'image face back)))))
-               (push ovly *go-board-overlays*)))
-         (hide (point)
-               (let ((ovly (make-overlay point (1+ point))))
-                 (overlay-put ovly 'invisible t)
-                 (push ovly *go-board-overlays*))))
+              (let ((ovly (make-overlay point (1+ point))))
+                (overlay-put ovly 'go-pt point)
+                (overlay-put ovly 'face (sym-cat 'go-board face))
+                (when go-board-use-images
+                  (overlay-put ovly 'display
+                               (if (equal face 'filler)
+                                   '(space :width (18))
+                                 (eval (sym-cat 'go-board 'image face back)))))
+                (push ovly *go-board-overlays*)))
+            (hide (point)
+              (let ((ovly (make-overlay point (1+ point))))
+                (overlay-put ovly 'invisible t)
+                (push ovly *go-board-overlays*))))
     (let ((start (or start (point-min)))
           (end   (or end   (point-max))))
       (dolist (point (range start end))
@@ -348,7 +348,7 @@
 (defun go-board-act ()
   "Send a command to the current GO board."
   (interactive)
-  (let ((command (go-completing-read
+  (let ((command (completing-read
                   "Action: " (mapcar #'symbol-name go-board-actions))))
     (case (intern command)
       (move    (message "make a move"))
@@ -361,20 +361,20 @@
   (let* ((color (case *turn* (:B "black") (:W "white")))
          (pos (or pos (cons (char-to-num
                              (aref (downcase
-                                    (go-completing-read
+                                    (completing-read
                                      (format "[%s] X pos: " color)
                                      (mapcar #'string
                                              (mapcar #'gtp-num-to-char
                                                      (range 1 *size*)))))
                                    0))
                             (1- (string-to-number
-                                 (go-completing-read
+                                 (completing-read
                                   (format "[%s] Y pos: " color)
                                   (mapcar #'number-to-string
                                           (range 1 *size*))))))))
          (move (cons *turn* (cons :pos pos))))
     (with-backends back
-      (setf (go-move back) move))
+                   (setf (go-move back) move))
     (setf *turn* (other-color *turn*))
     (apply-turn-to-board (list move)))
   (when *autoplay* (go-board-next)))
@@ -507,10 +507,10 @@
 
 (cl-defmethod set-go-move ((board board) move)
   (with-board board
-    (setf *turn* (other-color *turn*))
-    (apply-turn-to-board (list move))
-    (goto-char (point-of-pos (cddr move)))
-    (with-trackers tr (setf (go-move tr) move))))
+              (setf *turn* (other-color *turn*))
+              (apply-turn-to-board (list move))
+              (goto-char (point-of-pos (cddr move)))
+              (with-trackers tr (setf (go-move tr) move))))
 
 (cl-defmethod go-labels ((board board))
   (signal 'unsupported-back-end-command (list board :labels)))
@@ -560,16 +560,16 @@
 
 (cl-defmethod go-pass ((board board))
   (with-board board
-    (message "pass")
-    (setf *turn* (other-color *turn*))))
+              (message "pass")
+              (setf *turn* (other-color *turn*))))
 
 (cl-defmethod go-resign ((board board))
   (with-board board (message "%s resign" *turn*)))
 
 (cl-defmethod go-reset ((board board))
   (with-board board
-    (setf *history* nil)
-    (update-display)))
+              (setf *history* nil)
+              (update-display)))
 
 (cl-defmethod go-quit ((board board))
   (with-board board (go-quit)))

--- a/go-util.el
+++ b/go-util.el
@@ -168,9 +168,5 @@
               (mapc (lambda (s) (funcall func proc s)) lines)))
           (when moving (goto-char (process-mark proc))))))))
 
-(defalias 'go-completing-read (if (fboundp 'org-icompleting-read)
-                                  'org-icompleting-read
-                                'completing-read))
-
 (provide 'go-util)
 ;;; go-util.el ends here

--- a/go.el
+++ b/go.el
@@ -52,7 +52,7 @@
   (interactive)
   ;; TODO: read and set handicap.
   (let ((it (make-instance back-end))
-        (size (read (go-completing-read
+        (size (read (completing-read
                      "board size: "
                      (mapcar #'number-to-string '(19 13 9))))))
     (go-connect it)
@@ -63,7 +63,7 @@
 (defun go-play ()
   "Play a game of GO."
   (interactive)
-  (let ((back-end (case (intern (go-completing-read
+  (let ((back-end (case (intern (completing-read
                                  "play against: " '("gnugo" "person")))
                     (gnugo  (go-instantiate 'gnugo))
                     (person (go-instantiate 'sgf)))))


### PR DESCRIPTION
`org-icompleting-read` was deprecated in [9.0](https://git.savannah.gnu.org/cgit/emacs/org-mode.git/commit/?id=fdbf44156060297a0536b79a198fba13619b1d9b).

Includes some unrelated formatting changes due to on-save handlers.