### PR TITLE
fix(#13): Remove take re-definition

### DIFF
--- a/go-util.el
+++ b/go-util.el
@@ -64,8 +64,6 @@
       (let ((res (number-sequence a b)))
         (if tmp (nreverse res) res)))))
 
-(defun take (num list) (subseq list 0 num))
-
 (defun set-aget (list key new)
   (if (aget list key)
       (setf (cdr (assoc key list)) new)


### PR DESCRIPTION
`take` is already implemented and removing this re-definition.

Fixes #13.