### PR TITLE
fix(#16): Restore aget

### DIFF
--- a/go-util.el
+++ b/go-util.el
@@ -23,6 +23,56 @@
 ;;; Code:
 (eval-when-compile (require 'cl))
 
+(defun aget (alist key &optional keynil-p)
+  "Return the value in ALIST that is associated with KEY.
+Optional KEYNIL-P describes what to do if the value associated with
+KEY is nil.  If KEYNIL-P is not supplied or is nil, and the value is
+nil, then KEY is returned.  If KEYNIL-P is non-nil, then nil would be
+returned.
+
+If no key-value pair matching KEY could be found in ALIST, or ALIST is
+nil then nil is returned.  ALIST is not altered.
+
+Fix #16: Replace with modern alternative."
+  (defvar assoc--copy)
+  (let ((assoc--copy (copy-alist alist)))
+    (cond ((null alist) nil)
+          ((progn (asort 'assoc--copy key) ; dynamic binding
+                  (anot-head-p assoc--copy key)) nil)
+          ((cdr (car assoc--copy)))
+          (keynil-p nil)
+          ((car (car assoc--copy)))
+          (t nil))))
+
+(defun asort (alist-symbol key)
+  "Move a specified key-value pair to the head of an alist.
+The alist is referenced by ALIST-SYMBOL.  Key-value pair to move to
+head is one matching KEY.  Returns the sorted list and doesn't affect
+the order of any other key-value pair.  Side effect sets alist to new
+sorted list.
+
+Fix #16: Replace with modern alternative."
+
+  (set alist-symbol
+       (sort (copy-alist (symbol-value alist-symbol))
+             (lambda (a _b) (equal (car a) key)))))
+
+(defun aheadsym (alist)
+  "Return the key symbol at the head of ALIST.
+
+Fix #16: Replace with modern alternative."
+  (car (car alist)))
+
+(defun anot-head-p (alist key)
+  "Find out if a specified key-value pair is not at the head of an alist.
+The alist to check is specified by ALIST and the key-value pair is the
+one matching the supplied KEY.  Returns nil if ALIST is nil, or if
+key-value pair is at the head of the alist.  Returns t if key-value
+pair is not at the head of alist.  ALIST is not altered.
+
+Fix #16: Replace with modern alternative."
+  (not (equal (aheadsym alist) key)))
+
 (defun curry (function &rest arguments)
   (lexical-let ((function function)
                 (arguments arguments))


### PR DESCRIPTION
Restore aget and related functions which were deprecated and removed in 2013. This is a temporary patch while we implement modern alternatives.